### PR TITLE
add support for custom headers in API requests

### DIFF
--- a/lib/modules/api/types.ts
+++ b/lib/modules/api/types.ts
@@ -1,5 +1,6 @@
 export interface QueryMeta extends Record<string, unknown> {
   redirectToLocationIfUnauthorized?: string | boolean;
+  headers?: Record<string, string> | (() => Record<string, string>) | (() => Promise<Record<string, string>>);
 }
 
 declare module '@tanstack/react-query' {

--- a/lib/modules/api/utils.ts
+++ b/lib/modules/api/utils.ts
@@ -93,7 +93,7 @@ const notUndefinedEntry = <T>(entry: [string, T | undefined]): entry is [string,
 
 const getHeaders = async (meta?: QueryMeta) => {
   if (typeof meta?.headers === 'function') {
-    return (await meta?.headers()) ?? {};
+    return (await meta.headers()) ?? {};
   }
   return meta?.headers ?? {};
 };

--- a/lib/modules/api/utils.ts
+++ b/lib/modules/api/utils.ts
@@ -91,6 +91,13 @@ const notUndefinedEntry = <T>(entry: [string, T | undefined]): entry is [string,
   return entry[1] !== undefined;
 };
 
+const getHeaders = async (meta?: QueryMeta) => {
+  if (typeof meta?.headers === 'function') {
+    return await meta?.headers();
+  }
+  return meta?.headers;
+};
+
 /**
  * Generate a function that fetches a list of items from the API.
  * The fetch call uses GET.
@@ -106,6 +113,7 @@ export const generateFindMethod = <T>(url: string, host?: string) => {
       method: 'GET',
       credentials: 'include',
       redirect: 'error',
+      headers: await getHeaders(context.meta),
     });
 
     await checkResponseErrors(response, context.meta?.redirectToLocationIfUnauthorized);
@@ -129,6 +137,7 @@ export const generateGetMethod = <T>(url: string, host?: string) => {
       method: 'GET',
       credentials: 'include',
       redirect: 'error',
+      headers: await getHeaders(context.meta),
     });
 
     await checkResponseErrors(response, context.meta?.redirectToLocationIfUnauthorized);
@@ -152,6 +161,7 @@ export const generateCreateMethod = <T>(url: string, host?: string) => {
       credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
+        ...(await getHeaders(meta)),
       },
       body: JSON.stringify(data),
     });
@@ -177,6 +187,7 @@ export const generateUpdateMethod = <T>(url: string, host?: string) => {
       credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
+        ...(await getHeaders(meta)),
       },
       body: JSON.stringify(data),
     });
@@ -202,6 +213,7 @@ export const generateDeleteMethod = <T>(url: string, host?: string) => {
       credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
+        ...(await getHeaders(meta)),
       },
     });
 
@@ -230,6 +242,7 @@ export const generateFormMethod = <T>(url: string, host?: string) => {
       method: 'POST',
       credentials: 'include',
       body: formData,
+      headers: await getHeaders(meta),
     });
 
     await checkResponseErrors(response, meta?.redirectToLocationIfUnauthorized);

--- a/lib/modules/api/utils.ts
+++ b/lib/modules/api/utils.ts
@@ -93,9 +93,9 @@ const notUndefinedEntry = <T>(entry: [string, T | undefined]): entry is [string,
 
 const getHeaders = async (meta?: QueryMeta) => {
   if (typeof meta?.headers === 'function') {
-    return await meta?.headers();
+    return (await meta?.headers()) ?? {};
   }
-  return meta?.headers;
+  return meta?.headers ?? {};
 };
 
 /**


### PR DESCRIPTION
This pull request introduces support for dynamic and asynchronous headers in API requests by extending the `QueryMeta` interface and updating utility functions to handle such headers. These changes improve the flexibility and customization of API calls.

### Enhancements to API request handling:

* **Dynamic and asynchronous headers support**:
  - Updated the `QueryMeta` interface in `lib/modules/api/types.ts` to include an optional `headers` property, which can be a static object, a synchronous function, or an asynchronous function.
  - Added a new `getHeaders` utility function in `lib/modules/api/utils.ts` to resolve the `headers` property from `QueryMeta`, supporting both synchronous and asynchronous functions.

* **Integration of dynamic headers in API methods**:
  - Updated the `generateFindMethod`, `generateGetMethod`, `generateCreateMethod`, `generateUpdateMethod`, `generateDeleteMethod`, and `generateFormMethod` functions in `lib/modules/api/utils.ts` to use the `getHeaders` function for resolving and including headers in API requests. [[1]](diffhunk://#diff-d94af9b183f993be4bc6e4ace86bd7ae19f00ad45ff8cd585d4265cfa22459d3R116) [[2]](diffhunk://#diff-d94af9b183f993be4bc6e4ace86bd7ae19f00ad45ff8cd585d4265cfa22459d3R140) [[3]](diffhunk://#diff-d94af9b183f993be4bc6e4ace86bd7ae19f00ad45ff8cd585d4265cfa22459d3R164) [[4]](diffhunk://#diff-d94af9b183f993be4bc6e4ace86bd7ae19f00ad45ff8cd585d4265cfa22459d3R190) [[5]](diffhunk://#diff-d94af9b183f993be4bc6e4ace86bd7ae19f00ad45ff8cd585d4265cfa22459d3R216) [[6]](diffhunk://#diff-d94af9b183f993be4bc6e4ace86bd7ae19f00ad45ff8cd585d4265cfa22459d3R245)

<!-- Before creating a PR

✔ I rechecked the ticket and all requirements are fulfilled.

✔ I checked the Readme and made sure it is up-to-date.

✔ I added tests for the new code if possible.

✔ I rebased the feature branch on the main branch.

✔ I linked the ticket to this PR by either
  - adding `closes #issueId` if PR should close the issue
  - or adding `for #issueId` if PR should relate to an issue

✔ I enabled auto-merge if the PR can be merged after approval

✔ I informed my colleagues in slack about the PR / offered a walkthrough

-->

### PR instructions

<!--

✔ I wrote clear instructions how to set up and test the PR.

✔ I executed the PR instructions myself and everything worked.

-->

### The steps of acceptance

✔ I executed the PR instructions and everything worked.

✔ I checked the requirements for the ticket, and they are matching the PR.

✔ I am satisfied with the code and left annotations if I had some ideas.
