### PR TITLE
Feat/sort sticky tables

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  { ignores: ['dist'] },
+  { ignores: ['dist', 'docs'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -38,7 +38,7 @@ export { Progress } from './modules/loading/Progress';
 export { i18nTheyReact } from './modules/locales/i18n.ts';
 
 export { formatCurrency, formatDateString, formatDateTimeString } from './modules/table/formatters';
-export type { TableColumns } from './modules/table/types';
+export type { TableColumns, TableColumn, TableColumnSortFunction, SortState, SortDirection } from './modules/table/types';
 export { StickyTable } from './modules/table/StickyTable';
 
 export type { Tabs } from './modules/tabs/types';

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -40,10 +40,7 @@ export { i18nTheyReact } from './modules/locales/i18n.ts';
 export { formatCurrency, formatDateString, formatDateTimeString } from './modules/table/formatters';
 export type {
   TableColumns,
-  TableColumn,
   TableColumnSortFunction,
-  SortState,
-  SortDirection,
 } from './modules/table/types';
 export { StickyTable } from './modules/table/StickyTable';
 

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -38,10 +38,7 @@ export { Progress } from './modules/loading/Progress';
 export { i18nTheyReact } from './modules/locales/i18n.ts';
 
 export { formatCurrency, formatDateString, formatDateTimeString } from './modules/table/formatters';
-export type {
-  TableColumns,
-  TableColumnSortFunction,
-} from './modules/table/types';
+export type { TableColumns, TableColumnSortFunction } from './modules/table/types';
 export { StickyTable } from './modules/table/StickyTable';
 
 export type { Tabs } from './modules/tabs/types';

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -38,7 +38,13 @@ export { Progress } from './modules/loading/Progress';
 export { i18nTheyReact } from './modules/locales/i18n.ts';
 
 export { formatCurrency, formatDateString, formatDateTimeString } from './modules/table/formatters';
-export type { TableColumns, TableColumn, TableColumnSortFunction, SortState, SortDirection } from './modules/table/types';
+export type {
+  TableColumns,
+  TableColumn,
+  TableColumnSortFunction,
+  SortState,
+  SortDirection,
+} from './modules/table/types';
 export { StickyTable } from './modules/table/StickyTable';
 
 export type { Tabs } from './modules/tabs/types';

--- a/lib/modules/locales/i18n.ts
+++ b/lib/modules/locales/i18n.ts
@@ -9,6 +9,23 @@ export const i18nTheyReact: i18n = createInstance({
 
   interpolation: {
     escapeValue: false, // not needed for react as it escapes by default
+    format: (value, format, lng) => {
+      if (format === 'datetime' && value instanceof Date) {
+        return value.toLocaleDateString(lng);
+      }
+      if (format?.startsWith('datetime(') && value instanceof Date) {
+        // Simple datetime formatting - could be enhanced with more options
+        return value.toLocaleDateString(lng);
+      }
+      if (format?.startsWith('currency(') && typeof value === 'number') {
+        const currency = format.match(/currency\(([^)]+)\)/)?.[1] || 'USD';
+        return new Intl.NumberFormat(lng, {
+          style: 'currency',
+          currency: currency,
+        }).format(value);
+      }
+      return value;
+    },
   },
 
   resources: {

--- a/lib/modules/locales/i18n.ts
+++ b/lib/modules/locales/i18n.ts
@@ -9,49 +9,6 @@ export const i18nTheyReact: i18n = createInstance({
 
   interpolation: {
     escapeValue: false, // not needed for react as it escapes by default
-    format: (value, format, lng) => {
-      // Date/time formatting: {{date, datetime(...)}}
-      if ((format === 'datetime' || format?.startsWith('datetime(')) && value instanceof Date) {
-        // Parse options inside datetime(...)
-        const options: Intl.DateTimeFormatOptions = {};
-        const match = format?.match(/datetime\((.*)\)/);
-        if (match?.[1]) {
-          // Example: "year: numeric; month: numeric; day: numeric; hour: numeric; minute: numeric"
-          match[1]
-            .split(';')
-            .map((s) => s.trim())
-            .filter(Boolean)
-            .forEach((pair) => {
-              const [k, v] = pair.split(':').map((s) => s.trim());
-              if (!k || !v) return;
-              // Map to valid Intl options
-              const key = k as keyof Intl.DateTimeFormatOptions;
-              const val = v.replace(/,$/, '') as unknown;
-              (options as Record<string, unknown>)[key as string] = val;
-            });
-        }
-        // If no options given, default to date+time
-        const hasAny = Object.keys(options).length > 0;
-        const fmt = new Intl.DateTimeFormat(
-          lng,
-          hasAny
-            ? options
-            : { year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric', minute: 'numeric' }
-        );
-        return fmt.format(value);
-      }
-
-      // Currency formatting: {{value, currency(USD)}}
-      if (format?.startsWith('currency(') && typeof value === 'number') {
-        const currency = format.match(/currency\(([^)]+)\)/)?.[1] || 'USD';
-        return new Intl.NumberFormat(lng, {
-          style: 'currency',
-          currency,
-        }).format(value);
-      }
-
-      return value;
-    },
   },
 
   resources: {

--- a/lib/modules/locales/i18n.ts
+++ b/lib/modules/locales/i18n.ts
@@ -32,7 +32,12 @@ export const i18nTheyReact: i18n = createInstance({
         }
         // If no options given, default to date+time
         const hasAny = Object.keys(options).length > 0;
-        const fmt = new Intl.DateTimeFormat(lng, hasAny ? options : { year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric', minute: 'numeric' });
+        const fmt = new Intl.DateTimeFormat(
+          lng,
+          hasAny
+            ? options
+            : { year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric', minute: 'numeric' }
+        );
         return fmt.format(value);
       }
 

--- a/lib/modules/locales/i18n.ts
+++ b/lib/modules/locales/i18n.ts
@@ -26,8 +26,8 @@ export const i18nTheyReact: i18n = createInstance({
               if (!k || !v) return;
               // Map to valid Intl options
               const key = k as keyof Intl.DateTimeFormatOptions;
-              const val = v.replace(/,$/, '') as any;
-              (options as any)[key] = val;
+              const val = v.replace(/,$/, '') as unknown;
+              (options as Record<string, unknown>)[key as string] = val;
             });
         }
         // If no options given, default to date+time

--- a/lib/modules/table/StickyTable.tsx
+++ b/lib/modules/table/StickyTable.tsx
@@ -59,7 +59,7 @@ export const StickyTable = <T,>({
   };
 
   const handleSort = (column: Path<T>) => {
-    setSortState(prevState => {
+    setSortState((prevState) => {
       if (prevState.column === column) {
         // Toggle direction if same column
         return {

--- a/lib/modules/table/StickyTable.tsx
+++ b/lib/modules/table/StickyTable.tsx
@@ -3,7 +3,7 @@ import { TableColumns, SortState } from './types';
 import { Progress } from '../loading/Progress';
 import { StickyTableHead } from './StickyTableHead';
 import { StickyTableBody } from './StickyTableBody';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { useCan } from '../auth/hooks';
 import { i18nTheyReact } from '../locales/i18n';
 import { I18nextProvider } from 'react-i18next';
@@ -79,7 +79,9 @@ export const StickyTable = <T,>({
   };
 
   // Sort the data before pagination
-  const sortedData = sortData(data, columns, sortState);
+  const sortedData = useMemo(() => {
+    return sortData(data, columns, sortState);
+  }, [data, columns, sortState]);
 
   if (error) {
     return (

--- a/lib/modules/table/StickyTableHead.tsx
+++ b/lib/modules/table/StickyTableHead.tsx
@@ -13,11 +13,6 @@ type Props<T> = {
 };
 
 export const StickyTableHead = <T,>({ columns, onAdd, extraCol, sortState, onSort }: Props<T>) => {
-  const handleSort = (column: Path<T>) => {
-    if (onSort) {
-      onSort(column);
-    }
-  };
 
   return (
     <TableHead>
@@ -37,7 +32,7 @@ export const StickyTableHead = <T,>({ columns, onAdd, extraCol, sortState, onSor
                 <TableSortLabel
                   active={isActive}
                   direction={direction || 'asc'}
-                  onClick={() => handleSort(column.name)}
+                  onClick={() => onSort(column.name)}
                   sx={{
                     color: 'inherit !important',
                     '& .MuiTableSortLabel-icon': {

--- a/lib/modules/table/StickyTableHead.tsx
+++ b/lib/modules/table/StickyTableHead.tsx
@@ -13,7 +13,6 @@ type Props<T> = {
 };
 
 export const StickyTableHead = <T,>({ columns, onAdd, extraCol, sortState, onSort }: Props<T>) => {
-
   return (
     <TableHead>
       <TableRow>

--- a/lib/modules/table/StickyTableHead.tsx
+++ b/lib/modules/table/StickyTableHead.tsx
@@ -1,27 +1,58 @@
-import { IconButton, TableHead, TableRow } from '@mui/material';
+import { IconButton, TableHead, TableRow, TableSortLabel } from '@mui/material';
 import { Add as AddIcon } from '@mui/icons-material';
 import { StyledTableCell } from './StyledTableCell';
-import { TableColumns } from './types';
+import { TableColumns, SortState, SortDirection } from './types';
+import { Path } from 'react-hook-form';
 
 type Props<T> = {
   columns: TableColumns<T>;
   onAdd?: () => void;
   extraCol?: boolean;
+  sortState?: SortState<T>;
+  onSort?: (column: Path<T>) => void;
 };
 
-export const StickyTableHead = <T,>({ columns, onAdd, extraCol }: Props<T>) => {
+export const StickyTableHead = <T,>({ columns, onAdd, extraCol, sortState, onSort }: Props<T>) => {
+  const handleSort = (column: Path<T>) => {
+    if (onSort) {
+      onSort(column);
+    }
+  };
+
   return (
     <TableHead>
       <TableRow>
-        {columns.map((column) => (
-          <StyledTableCell
-            key={column.key ?? column.name}
-            align={column.align}
-            style={{ minWidth: column.minWidth }}
-          >
-            {column.label}
-          </StyledTableCell>
-        ))}
+        {columns.map((column) => {
+          const isActive = sortState?.column === column.name;
+          const direction: SortDirection | false = isActive ? sortState.direction : false;
+
+          return (
+            <StyledTableCell
+              key={column.key ?? column.name}
+              align={column.align}
+              style={{ minWidth: column.minWidth }}
+              sortDirection={direction}
+            >
+              {column.sortable && onSort ? (
+                <TableSortLabel
+                  active={isActive}
+                  direction={direction || 'asc'}
+                  onClick={() => handleSort(column.name)}
+                  sx={{
+                    color: 'inherit !important',
+                    '& .MuiTableSortLabel-icon': {
+                      color: 'inherit !important',
+                    },
+                  }}
+                >
+                  {column.label}
+                </TableSortLabel>
+              ) : (
+                column.label
+              )}
+            </StyledTableCell>
+          );
+        })}
         {(onAdd || extraCol) && (
           <StyledTableCell align="right">
             {onAdd && (

--- a/lib/modules/table/formatters.ts
+++ b/lib/modules/table/formatters.ts
@@ -6,29 +6,19 @@ export const formatCurrency = (value: number, t: TFunction): string => {
 
 export const formatDateString = (value: string, t: TFunction) => {
   try {
-    const date = new Date(value);
-    if (isNaN(date.getTime())) {
-      console.error(`Invalid date string: ${value}`);
-      return value; // Return original value if invalid
-    }
-    return t('format.date', { date });
-  } catch (error) {
-    console.error(`Could not format date: ${value}`, error);
-    return value; // Return original value on error
+    return t('format.date', { date: new Date(value) });
+  } catch {
+    console.error(`Could not format date: ${value}`);
+    return '';
   }
 };
 
 export const formatTimeString = (value: string, t: TFunction) => {
   try {
-    const date = new Date(value);
-    if (isNaN(date.getTime())) {
-      console.error(`Invalid time string: ${value}`);
-      return value;
-    }
-    return t('format.time', { date });
-  } catch (error) {
-    console.error(`Could not format time: ${value}`, error);
-    return value;
+    return t('format.time', { date: new Date(value) });
+  } catch {
+    console.error(`Could not format time: ${value}`);
+    return '';
   }
 };
 

--- a/lib/modules/table/formatters.ts
+++ b/lib/modules/table/formatters.ts
@@ -6,19 +6,29 @@ export const formatCurrency = (value: number, t: TFunction): string => {
 
 export const formatDateString = (value: string, t: TFunction) => {
   try {
-    return t('format.date', { value: new Date(value) });
-  } catch {
-    console.error(`Could not format date: ${value}`);
-    return '';
+    const date = new Date(value);
+    if (isNaN(date.getTime())) {
+      console.error(`Invalid date string: ${value}`);
+      return value; // Return original value if invalid
+    }
+    return t('format.date', { date });
+  } catch (error) {
+    console.error(`Could not format date: ${value}`, error);
+    return value; // Return original value on error
   }
 };
 
 export const formatTimeString = (value: string, t: TFunction) => {
   try {
-    return t('format.time', { value: new Date(value) });
-  } catch {
-    console.error(`Could not format time: ${value}`);
-    return '';
+    const date = new Date(value);
+    if (isNaN(date.getTime())) {
+      console.error(`Invalid time string: ${value}`);
+      return value;
+    }
+    return t('format.time', { date });
+  } catch (error) {
+    console.error(`Could not format time: ${value}`, error);
+    return value;
   }
 };
 

--- a/lib/modules/table/types.ts
+++ b/lib/modules/table/types.ts
@@ -8,6 +8,13 @@ export type TableColumnFormatter<T, P extends Path<T>> = (
   data: T
 ) => ReactNode;
 
+export type TableColumnSortFunction<T, P extends Path<T>> = (
+  a: PathValue<T, P>,
+  b: PathValue<T, P>,
+  aRow: T,
+  bRow: T
+) => number;
+
 export type TableColumn<T, P extends Path<T>> = {
   key?: string;
   name: P;
@@ -16,8 +23,17 @@ export type TableColumn<T, P extends Path<T>> = {
   align?: 'left' | 'right' | 'center';
   format?: TableColumnFormatter<T, P>;
   empty?: ReactNode;
+  sortable?: boolean;
+  sortFunction?: TableColumnSortFunction<T, P>;
 };
 
 export type TableColumns<T> = {
   [K in Path<T>]: TableColumn<T, K>;
 }[Path<T>][];
+
+export type SortDirection = 'asc' | 'desc';
+
+export type SortState<T> = {
+  column: Path<T> | null;
+  direction: SortDirection;
+};

--- a/lib/modules/table/utils.ts
+++ b/lib/modules/table/utils.ts
@@ -1,6 +1,6 @@
 import { Path, PathValue } from 'react-hook-form';
 import { get } from 'lodash';
-import { TableColumnFormatter } from './types';
+import { TableColumnFormatter, TableColumns, SortState, SortDirection } from './types';
 import { ReactNode } from 'react';
 import { TFunction } from 'i18next';
 
@@ -20,4 +20,73 @@ export const formatValue = <T, P extends Path<T>>(
     return empty ?? '-';
   }
   return (format ? format(value, t, row) : value.toString()) || (empty ?? '-');
+};
+
+const defaultSortFunction = <T, P extends Path<T>>(
+  a: PathValue<T, P>,
+  b: PathValue<T, P>
+): number => {
+  // Handle null/undefined values
+  if (a === null || a === undefined) return b === null || b === undefined ? 0 : 1;
+  if (b === null || b === undefined) return -1;
+
+  // Handle string comparison (check if they might be dates first)
+  if (typeof a === 'string' && typeof b === 'string') {
+    // Try to parse as dates if they look like ISO date strings
+    const dateA = new Date(a);
+    const dateB = new Date(b);
+    if (!isNaN(dateA.getTime()) && !isNaN(dateB.getTime())) {
+      return dateA.getTime() - dateB.getTime();
+    }
+    return a.localeCompare(b);
+  }
+
+  // Handle number comparison
+  if (typeof a === 'number' && typeof b === 'number') {
+    return a - b;
+  }
+
+  // Handle date comparison
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() - b.getTime();
+  }
+
+  // Handle boolean comparison
+  if (typeof a === 'boolean' && typeof b === 'boolean') {
+    return a === b ? 0 : a ? -1 : 1;
+  }
+
+  // Fallback to string comparison
+  return String(a).localeCompare(String(b));
+};
+
+export const sortData = <T>(
+  data: T[],
+  columns: TableColumns<T>,
+  sortState: SortState<T>
+): T[] => {
+  if (!sortState.column) {
+    return data;
+  }
+
+  const column = columns.find(col => col.name === sortState.column);
+  if (!column) {
+    return data;
+  }
+
+  const sortedData = [...data].sort((a, b) => {
+    const aValue = getValue(a, sortState.column!);
+    const bValue = getValue(b, sortState.column!);
+
+    let result: number;
+    if (column.sortFunction) {
+      result = column.sortFunction(aValue, bValue, a, b);
+    } else {
+      result = defaultSortFunction(aValue, bValue);
+    }
+
+    return sortState.direction === 'desc' ? -result : result;
+  });
+
+  return sortedData;
 };

--- a/lib/modules/table/utils.ts
+++ b/lib/modules/table/utils.ts
@@ -1,6 +1,6 @@
 import { Path, PathValue } from 'react-hook-form';
 import { get } from 'lodash';
-import { TableColumnFormatter, TableColumns, SortState, SortDirection } from './types';
+import { TableColumnFormatter, TableColumns, SortState } from './types';
 import { ReactNode } from 'react';
 import { TFunction } from 'i18next';
 

--- a/lib/modules/table/utils.ts
+++ b/lib/modules/table/utils.ts
@@ -22,10 +22,7 @@ export const formatValue = <T, P extends Path<T>>(
   return (format ? format(value, t, row) : value.toString()) || (empty ?? '-');
 };
 
-const defaultSortFunction = <T, P extends Path<T>>(
-  a: PathValue<T, P>,
-  b: PathValue<T, P>
-): number => {
+const defaultSortFunction = <T, P extends Path<T>>(a: PathValue<T, P>, b: PathValue<T, P>): number => {
   // Handle null/undefined values
   if (a === null || a === undefined) return b === null || b === undefined ? 0 : 1;
   if (b === null || b === undefined) return -1;
@@ -60,16 +57,12 @@ const defaultSortFunction = <T, P extends Path<T>>(
   return String(a).localeCompare(String(b));
 };
 
-export const sortData = <T>(
-  data: T[],
-  columns: TableColumns<T>,
-  sortState: SortState<T>
-): T[] => {
+export const sortData = <T>(data: T[], columns: TableColumns<T>, sortState: SortState<T>): T[] => {
   if (!sortState.column) {
     return data;
   }
 
-  const column = columns.find(col => col.name === sortState.column);
+  const column = columns.find((col) => col.name === sortState.column);
   if (!column) {
     return data;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@they-consulting/react",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Helper modules for an easier react life",
   "type": "module",
   "main": "dist/main.js",

--- a/src/modules/table/StickyTable.stories.tsx
+++ b/src/modules/table/StickyTable.stories.tsx
@@ -107,34 +107,29 @@ type FormattingTableEntity = {
   price: number;
   since: string;
 };
-export const Formatter: Story = {
+export const Formatter: StoryObj<typeof StickyTable<FormattingTableEntity>> = {
   args: {
     columns: [
-      // @ts-expect-error we change the data structure for this story
       {
         name: 'item',
         label: 'Item',
         format: (value: string) => value.toUpperCase(),
       },
-      // @ts-expect-error we change the data structure for this story
       {
         name: 'date',
         label: 'Date',
         format: formatDateString,
       },
-      // @ts-expect-error we change the data structure for this story
       {
         name: 'price',
         label: 'Price',
         format: formatCurrency,
       },
-      // @ts-expect-error we change the data structure for this story
       {
         name: 'since',
         label: 'Since',
         format: formatDateTimeString,
       },
-      // @ts-expect-error we change the data structure for this story
       {
         name: 'item',
         label: 'Combined',
@@ -153,6 +148,75 @@ export const Formatter: Story = {
         date: formatISO(new Date()),
         price: 2.345,
         since: formatISO(new Date()),
+      },
+    ],
+  },
+};
+
+type SortableTableEntity = {
+  name: string;
+  age: number;
+  score: number;
+  date: string;
+};
+
+export const WithSorting: StoryObj<typeof StickyTable<SortableTableEntity>> = {
+  args: {
+    columns: [
+      {
+        name: 'name',
+        label: 'Name',
+        sortable: true,
+      },
+      {
+        name: 'age',
+        label: 'Age',
+        sortable: true,
+      },
+      {
+        name: 'score',
+        label: 'Score',
+        sortable: true,
+        // Custom sort function for descending score by default
+        sortFunction: (a: number, b: number) => b - a,
+      },
+      {
+        name: 'date',
+        label: 'Date',
+        sortable: true,
+        format: formatDateString,
+      },
+    ],
+    data: [
+      {
+        name: 'Alice Johnson',
+        age: 28,
+        score: 95,
+        date: '2024-01-15',
+      },
+      {
+        name: 'Bob Smith',
+        age: 34,
+        score: 87,
+        date: '2024-02-20',
+      },
+      {
+        name: 'Charlie Brown',
+        age: 22,
+        score: 92,
+        date: '2024-01-10',
+      },
+      {
+        name: 'Diana Prince',
+        age: 31,
+        score: 98,
+        date: '2024-03-05',
+      },
+      {
+        name: 'Edward Norton',
+        age: 29,
+        score: 89,
+        date: '2024-02-28',
       },
     ],
   },


### PR DESCRIPTION
Adds sorting to the StickyTable component.

Additional fixes:
- fix date formatting functions
- Excludes /docs from linting.

Run the Storybook and check it out.

<!-- Before creating a PR

✔ I rechecked the ticket and all requirements are fulfilled.

✔ I checked the Readme and made sure it is up-to-date.

✔ I added tests for the new code if possible.

✔ I rebased the feature branch on the main branch.

✔ I linked the ticket to this PR by either
  - adding `closes #issueId` if PR should close the issue
  - or adding `for #issueId` if PR should relate to an issue

✔ I enabled auto-merge if the PR can be merged after approval

✔ I informed my colleagues in slack about the PR / offered a walkthrough

-->

### PR instructions

<!--

✔ I wrote clear instructions how to set up and test the PR.

✔ I executed the PR instructions myself and everything worked.

-->

### The steps of acceptance

✔ I executed the PR instructions and everything worked.

✔ I checked the requirements for the ticket, and they are matching the PR.

✔ I am satisfied with the code and left annotations if I had some ideas.
